### PR TITLE
Temporary fix for absolute path error in Python 3.5

### DIFF
--- a/resize/utils.py
+++ b/resize/utils.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def get_file_path(img_file):
     if isinstance(img_file, six.string_types):
         return img_file
-    if pathlib.Path(img_file).exists():
+    if pathlib.Path(img_file.path).exists():
         return img_file.path
     elif img_file is not None:
         return img_file.name

--- a/resize/utils.py
+++ b/resize/utils.py
@@ -21,10 +21,11 @@ logger = logging.getLogger(__name__)
 def get_file_path(img_file):
     if isinstance(img_file, six.string_types):
         return img_file
-    if pathlib.Path(img_file.path).exists():
-        return img_file.path
-    elif img_file is not None:
-        return img_file.name
+    else:
+        try:
+            return img_file.path
+        except:
+            return img_file.name
 
 
 def get_thumb_name(img_file, size):

--- a/resize/utils.py
+++ b/resize/utils.py
@@ -13,7 +13,6 @@ from django.core.files.images import ImageFile
 from django.utils import six
 
 from PIL import Image
-import pathlib
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is a fix for images not being able to save in Python 3.5. With the upgrade, saving photos will return `NotImplementedError: This backend doesn't support absolute paths.`